### PR TITLE
check for existing NODE_ENV before overwrite

### DIFF
--- a/NodePlatform_Ubuntu/builder/platform-uploads/opt/SampleNodePlatform/bin/createPM2ProcessFile.js
+++ b/NodePlatform_Ubuntu/builder/platform-uploads/opt/SampleNodePlatform/bin/createPM2ProcessFile.js
@@ -37,7 +37,7 @@ function getEnvParams(  ) {
 	var options = getOptions();
 	if(options) {
 		var envParams = options['aws:elasticbeanstalk:application:environment'];
-		envParams["NODE_ENV"] = "production";
+		if(!envParams["NODE_ENV"]) { envParams["NODE_ENV"] = "production"; } // NODE_ENV is set to productiion unless otherwise specified
 		if (envParams) { return envParams; }
 	}
 	return { "NODE_ENV" : "production" };


### PR DESCRIPTION
#7 

*Description of changes:*
Check the NODE_ENV has not already been set (through eb-cli or the eb console on AWS) before over-writing it with "production"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
